### PR TITLE
Fix/nullable expires at

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>voidpointer.spigot</groupId>
     <artifactId>voidwhitelist</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>VoidWhitelist</name>

--- a/src/main/java/voidpointer/spigot/voidwhitelist/storage/SimpleWhitelistable.java
+++ b/src/main/java/voidpointer/spigot/voidwhitelist/storage/SimpleWhitelistable.java
@@ -33,7 +33,6 @@ public final class SimpleWhitelistable extends AbstractWhitelistable {
     private UUID uniqueId;
     @NonNull
     private String name;
-    @NonNull
     private Date expiresAt;
 
     @Override public boolean isAssociatedWith(final Player player) {


### PR DESCRIPTION
#24 

The issue mentioned above relates to the `SimpleWhitelistable` implementation that, for some reason, had the `expiresAt` field marked as `@NonNull`, which is counterintuitive in its nature — we use `null` as `NEVER_EXPIRES`. This PR fixes this behaviour.